### PR TITLE
Support `stdin-placeholder` and `stdin-distinct` option

### DIFF
--- a/cmd/conk/main.go
+++ b/cmd/conk/main.go
@@ -20,6 +20,8 @@ func main() {
 	var onTickedCommand string
 	var dryRun bool
 	var shouldShowVersion bool
+	var stdinPlaceholder string
+	var stdinDistinct bool
 
 	flag.Uint64Var(&intervalDurationSec, "interval-sec", 0, "[mandatory] interval duration seconds to check the bytes that come from stdin.")
 	flag.StringVar(&onNotifiedCommand, "on-notified-cmd", "[]", "[semi-mandatory] command that runs on notified (i.e. when bytes come from stdin in an interval). this must be JSON string array. it requires this value and/or \"--on-not-notified-cmd\"")
@@ -27,6 +29,8 @@ func main() {
 	flag.StringVar(&onTickedCommand, "on-ticked-cmd", "[]", "command that runs every interval. this must be JSON string array.")
 	flag.BoolVar(&dryRun, "dry-run", false, "dry-run mode. if this value is true, it notifies the command was triggered, instead of executing commands.")
 	flag.BoolVar(&shouldShowVersion, "version", false, "show version info")
+	flag.StringVar(&stdinPlaceholder, "stdin-placeholder", "", "placeholder name that can be used in `on-notified-cmd` to give the command the arguments that come from STDIN.")
+	flag.BoolVar(&stdinDistinct, "stdin-distinct", false, "if this value is true, it makes the arguments for `on-notified-cmd` that come from STDIN distinct (i.e. makes them unique). see also: -stdin-placeholder")
 
 	flag.Usage = func() {
 		_, _ = fmt.Fprintf(os.Stderr, `A command-line tool that triggers command when the input (doesn't) comes from STDIN in an interval.
@@ -77,7 +81,7 @@ Options
 		log.Fatal(err)
 	}
 
-	err = conk.Run(time.Duration(intervalDurationSec)*time.Second, onNotifiedCmd, onNotNotifiedCmd, onTickedCmd, dryRun)
+	err = conk.Run(time.Duration(intervalDurationSec)*time.Second, onNotifiedCmd, onNotNotifiedCmd, onTickedCmd, dryRun, stdinPlaceholder, stdinDistinct)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/conk.go
+++ b/conk.go
@@ -6,27 +6,43 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 )
 
 // Run is the entry point of the application.
-func Run(intervalDuration time.Duration, onNotifiedCommand []string, onNotNotifiedCommand []string, onTickedCommand []string, dryRun bool) error {
+func Run(intervalDuration time.Duration, onNotifiedCommand []string, onNotNotifiedCommand []string, onTickedCommand []string, dryRun bool, stdinPlaceholder string, stdinDistinct bool) error {
 	onNotifiedCmdRunner := makeCommandRunner(onNotifiedCommand, dryRun)
 	onNotNotifiedCmdRunner := makeCommandRunner(onNotNotifiedCommand, dryRun)
 	onTickedCmdRunner := makeCommandRunner(onTickedCommand, dryRun)
+
+	var m sync.Mutex
+	stdinLines := make([]string, 0)
+	distinctMap := make(map[string]struct{})
 
 	notifyCh := make(chan interface{}, 1)
 	go func() {
 		ticker := time.Tick(intervalDuration)
 
 		for range ticker {
-			onTickedCmdRunner()
+			onTickedCmdRunner("")
 
 			select {
 			case <-notifyCh:
-				onNotifiedCmdRunner()
+				if stdinPlaceholder == "" {
+					onNotifiedCmdRunner("")
+					break
+				}
+
+				m.Lock()
+				onNotifiedCmdRunner(stdinPlaceholder, stdinLines...)
+				stdinLines = stdinLines[:0]
+				if stdinDistinct {
+					distinctMap = make(map[string]struct{})
+				}
+				m.Unlock()
 			default:
-				onNotNotifiedCmdRunner()
+				onNotNotifiedCmdRunner("")
 			}
 		}
 	}()
@@ -38,25 +54,41 @@ func Run(intervalDuration time.Duration, onNotifiedCommand []string, onNotNotifi
 		case notifyCh <- struct{}{}:
 		default:
 		}
+
+		if stdinPlaceholder != "" {
+			line := scanner.Text()
+
+			m.Lock()
+			if stdinDistinct {
+				if _, exists := distinctMap[line]; exists {
+					m.Unlock()
+					continue
+				}
+				distinctMap[line] = struct{}{}
+			}
+			stdinLines = append(stdinLines, line)
+			m.Unlock()
+		}
 	}
 
 	return scanner.Err()
 }
 
-func makeCommandRunner(commands []string, dryRun bool) func() {
+func makeCommandRunner(commands []string, dryRun bool) func(stdinPlaceholder string, stdinLines ...string) {
 	if len(commands) <= 0 {
-		return func() {}
+		return func(stdinPlaceholder string, stdinLines ...string) {}
 	}
 
 	if dryRun {
-		serializedCommands := strings.Join(commands, " ")
-		return func() {
-			log.Printf("[dry-run] triggered: `%s`", serializedCommands)
+		return func(stdinPlaceholder string, stdinLines ...string) {
+			serializedCommands := `"` + strings.Join(interpolateCommands(commands, stdinPlaceholder, stdinLines...), `" "`) + `"`
+			log.Printf("[dry-run] triggered: [%s]", serializedCommands)
 		}
 	}
 
-	return func() {
-		cmd := exec.Command(commands[0], commands[1:]...)
+	return func(stdinPlaceholder string, stdinLines ...string) {
+		cc := interpolateCommands(commands, stdinPlaceholder, stdinLines...)
+		cmd := exec.Command(cc[0], cc[1:]...)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		go func() { // don't wait the command finish
@@ -66,4 +98,40 @@ func makeCommandRunner(commands []string, dryRun bool) func() {
 			}
 		}()
 	}
+}
+
+var placeholderNumCache = -1
+
+func interpolateCommands(commands []string, stdinPlaceholder string, stdinLines ...string) []string {
+	if stdinPlaceholder == "" {
+		return commands
+	}
+
+	if placeholderNumCache < 0 { // initial run
+		placeholderNumCache = 0
+		interpolatedCommands := make([]string, 0, len(commands))
+		for _, command := range commands {
+			if command == stdinPlaceholder {
+				placeholderNumCache++
+				interpolatedCommands = append(interpolatedCommands, stdinLines...)
+				continue
+			}
+			interpolatedCommands = append(interpolatedCommands, command)
+		}
+		return interpolatedCommands
+	}
+
+	if placeholderNumCache == 0 {
+		return commands
+	}
+
+	interpolatedCommands := make([]string, 0, len(commands)-placeholderNumCache+len(stdinLines)*placeholderNumCache)
+	for _, command := range commands {
+		if command == stdinPlaceholder {
+			interpolatedCommands = append(interpolatedCommands, stdinLines...)
+			continue
+		}
+		interpolatedCommands = append(interpolatedCommands, command)
+	}
+	return interpolatedCommands
 }


### PR DESCRIPTION
`stdin-placeholder` option receives a placeholder name that can be used in `on-notified-cmd` to give the command the arguments that come from STDIN.

For example,

```
$ generator | conk -interval-sec 3 -on-notified-cmd '["echo", "{{__STDIN__}}"]' -stdin-placeholder '{{__STDIN__}}'
```

if the `generator` outputs `foo\nbar\nbuz\n` to STDOUT in 3 seconds, the conk command interpolates those texts in `{{__STDIN__}}`, like `["echo", "foo", "bar", "buz"].

And `stdin-distinct` option accepts the flag to instruct whether it makes the arguments for `on-notified-cmd` that come from STDIN distinct, i.e. makes them unique.

```
$ generator | conk -interval-sec 3 -on-notified-cmd '["echo", "{{__STDIN__}}"]' -stdin-placeholder '{{__STDIN__}}' -stdin-distinct
```

in these commands, if the `generator` outputs `foo\nbar\nfoo\nfoo` to STDOUT in 3 seconds, the conk command interpolates those texts in `{{__STDIN__}}` with unique arguments, like `["echo", "foo", "bar"] because `foo` is duplicated.